### PR TITLE
Corrige cor dos links nos cards dos roadmaps

### DIFF
--- a/roadmaps.css
+++ b/roadmaps.css
@@ -43,6 +43,11 @@ body {
   transform-origin: top;
 }
 
+.wrapper .row a {
+  color: var(--dark-purple);
+  text-decoration: underline;
+}
+
 .wrapper .row-1 {
   justify-content: flex-start;
 }


### PR DESCRIPTION
Os links dos cards dos roadmaps assumiram o estilo global e ficaram brancos, não havendo contraste, pois o fundo também é branco. Com isso, alterei especificamente a cor dos links inseridos nos cards e adicionei underline para que fique legível e destacado.